### PR TITLE
Add workflow for manual testing

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -1,0 +1,46 @@
+name: "Manual test"
+
+on:
+  workflow_dispatch:
+    inputs:
+      query:
+        default: "import go\nfrom File f select f"
+
+jobs:
+  run-query:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # This might not be the cleanest way to get hold of CodeQL but it's reliable
+    # and widely used. The ugly part is that is initialises a database of the
+    # given language that we just ignore.
+    - name: Initialize CodeQL
+      id: init
+      uses: github/codeql-action/init@v1
+      with:
+        languages: "go"
+
+    - name: Run query
+      uses: ./query
+      with:
+        query: ${{ github.event.inputs.query }}
+        language: "go"
+        repositories: "[{\"id\": 376068344, \"nwo\": \"dsp-testing/qc-demo-github-certstore\", \"pat\": \"${{ secrets.BOT_TOKEN }}\"}]"
+        codeql: ${{ steps.init.outputs.codeql-path }}
+
+  combine-results:
+    runs-on: ubuntu-latest
+    needs:
+    - run-query
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Combine results
+      uses: ./combine-results
+      with:
+        query: ${{ github.event.inputs.query }}
+        language: "go"
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow that can be triggered manually on any branch to test changes. That's the idea anyway.

I'm going to merge this myself without waiting for review as it's just adding a new workflow that's only triggered by `workflow_dispatch`. This will let me try it out and once it's on the default branch I should be fix any bugs by running the workflow against another branch before pushing any fixes.

cc @rneatherway for info