### PR TITLE
Fix manual test workflow

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -1,5 +1,13 @@
 name: "Manual test"
 
+# Allows running a Go query against the dsp-testing/qc-demo-github-certstore
+# test repo. Only works for that repo as it relies on a repository secret.
+# Can be triggered on test branches to test changes.
+
+# The Actions UI doesn't handle newlines in the inputs at all, so this
+# cannot be reliably triggered from the UI. For best results use the API.
+# e.g. curl https://api.github.com/repos/dsp-testing/qc-run2/actions/workflows/manual-test.yml/dispatches -X POST -d '{"ref":"my-branch", "inputs": {"query": "my query"}}'
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       query:
-        default: "import go\nfrom File f select f"
+        default: |
+          import go
+          from File f select f
 
 jobs:
   run-query:


### PR DESCRIPTION
Turns out the actions UI for triggering a workflow dispatch doesn't like newlines. As far as I can tell it just can't handle them.

This change means that if you trigger the workflow from the API without any inputs then it works. And you can specify newlines in the query if using the API. I think unfortunately this workflow will just have to be API-only as I think that being able to specify the query text if a necessity.