### PR TITLE
Add zero length arg to sed -i

### DIFF
--- a/script/use-main
+++ b/script/use-main
@@ -4,4 +4,4 @@ set -eu
 
 cd "$(dirname "$0")/.."
 
-sed -i -e "s#\(uses: dsp-testing/qc-run2/.*@\).*#\1main#g" .github/workflows/codeql-query.yml
+sed -i "" -e "s#\(uses: dsp-testing/qc-run2/.*@\).*#\1main#g" .github/workflows/codeql-query.yml

--- a/script/use-this-branch
+++ b/script/use-this-branch
@@ -4,4 +4,4 @@ set -eu
 
 cd "$(dirname "$0")/.."
 
-sed -i -e "s#\(uses: dsp-testing/qc-run2/.*@\).*#\1$(git branch --show-current)#g" .github/workflows/codeql-query.yml
+sed -i "" -e "s#\(uses: dsp-testing/qc-run2/.*@\).*#\1$(git branch --show-current)#g" .github/workflows/codeql-query.yml


### PR DESCRIPTION
If I run `script/use-this-branch` on OSX then it does what it's meant to do but it also creates a file called `.github/workflows/codeql-query.yml-e`. I'm assuming this is coming from a difference between the `-i` arg on linux vs osx.

For me, `man sed` says
```
     -i extension
             Edit files in-place, saving backups with the specified extension.  If a zero-length extension is given, no backup will be saved.  It is not
             recommended to give a zero-length extension when in-place editing files, as you risk corruption or partial content in situations where disk
             space is exhausted, etc.
```

Does this change still work for you on linux too? If not we can look for alternatives for doing the replacement, or just live with it...